### PR TITLE
Echo a newline to fix missing first variable issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ else
   USERNAME="${connectionParts[0]}"
 fi
 
+echo ""
 echo ::set-output name=username::"${USERNAME}"
 echo ::set-output name=password::"${connectionParts[1]}"
 echo ::set-output name=registry::"${connectionParts[2]}"


### PR DESCRIPTION
It appears that because the `::set-output` for `username` doesn't start on it's own newline, the value is ignored by the github actions parser.

I believe outputting a newline above the username export should fix this.