### PR TITLE
Use get-authorization-token to get credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "maintainer"="Lars Gohr"
 
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache python py-pip bash \
+  && apk add --no-cache python py-pip bash jq \
   && pip install awscli  \
   && apk --purge -v del py-pip
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-aws configure <<-EOF
-$INPUT_ACCESS_KEY
-$INPUT_SECRET_ACCESS_KEY
-$INPUT_REGION
-text
-EOF
+export AWS_ACCESS_KEY_ID=$INPUT_ACCESS_KEY
+export AWS_SECRET_ACCESS_KEY=$INPUT_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=$INPUT_REGION
 
 authTokenOutput=$(aws ecr get-authorization-token)
 authString=$(echo "$authTokenOutput" | jq -r '.authorizationData[].authorizationToken' | base64 -d)

--- a/mock.sh
+++ b/mock.sh
@@ -23,6 +23,6 @@ if [ "${parameters}" = "configure" ]; then
     exit 1
   fi
 else
-  echo "docker login -u AWS -p PASSWORD -e none https://dkr.ecr.amazonaws.com"
+  echo '{"authorizationData":[{"authorizationToken":"QVdTOkFVVEhfUEFTU1dPUkQK","expiresAt":1569961966.371,"proxyEndpoint":"https://ACCOUNTID.dkr.ecr.us-east-1.amazonaws.com"}]}'
 fi
 exit 0

--- a/test.bats
+++ b/test.bats
@@ -4,8 +4,9 @@
   run /entrypoint.sh
 
     local expected='::set-output name=username::AWS
-::set-output name=password::PASSWORD
-::set-output name=registry::https://dkr.ecr.amazonaws.com'
+::add-mask::AUTH_PASSWORD
+::set-output name=password::AUTH_PASSWORD
+::set-output name=registry::https://ACCOUNTID.dkr.ecr.us-east-1.amazonaws.com'
     echo $output
     [ "$output" = "$expected" ]
 }


### PR DESCRIPTION
This PR switches to using `get-authorization-token` instead of `get-login`, which is the intended API for programmatic access. The output for that call is more predictable, which gives a more predictable and future proof behavior. I've also added a working password mask, and passing credentials through environment variables instead of `aws configure`, which reduces the risk of secrets being outputted in logs.