### PR TITLE
Fix broken actions status badge, target main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ECR-Login-Action
 
-[![Actions Status](https://github.com/elgohr/ecr-login-action/workflows/Test/badge.svg)](https://github.com/elgohr/ecr-login-action/actions)
+[![Actions Status](https://github.com/elgohr/ecr-login-action/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/elgohr/ecr-login-action/actions)
 
 This Action for Docker logs into [AWS ECR](https://aws.amazon.com/de/ecr/) and gets the timely bound credentials for Docker.
 


### PR DESCRIPTION
💁 The "Test" workflow was deleted in d26da328b333f55970702bd66d7b6fa051f10d0c and the job within was migrated into a new workflow named "Release". That caused the URL for this status badge to break. These changes update that reference to fix the broken image and scope the status of the badge to the main branch.